### PR TITLE
Support DRF >=3.11.0 validator API changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ matrix:
     - python: 3.6
       env: TOX_ENV=py36-django111-drf310
     - python: 3.6
+      env: TOX_ENV=py36-django111-drf311
+    - python: 3.6
       env: TOX_ENV=py36-django20-drf37
     - python: 3.6
       env: TOX_ENV=py36-django20-drf38
@@ -18,6 +20,8 @@ matrix:
       env: TOX_ENV=py36-django20-drf39
     - python: 3.6
       env: TOX_ENV=py36-django20-drf310
+    - python: 3.6
+      env: TOX_ENV=py36-django20-drf311
     - python: 3.6
       env: TOX_ENV=py36-django21-drf37
     - python: 3.6
@@ -27,6 +31,8 @@ matrix:
     - python: 3.6
       env: TOX_ENV=py36-django21-drf310
     - python: 3.6
+      env: TOX_ENV=py36-django21-drf311
+    - python: 3.6
       env: TOX_ENV=py36-django22-drf37
     - python: 3.6
       env: TOX_ENV=py36-django22-drf38
@@ -34,6 +40,8 @@ matrix:
       env: TOX_ENV=py36-django22-drf39
     - python: 3.6
       env: TOX_ENV=py36-django22-drf310
+    - python: 3.6
+      env: TOX_ENV=py36-django22-drf311
     - python: 3.7
       env: TOX_ENV=py37-django111-drf37
     - python: 3.7
@@ -43,6 +51,8 @@ matrix:
     - python: 3.7
       env: TOX_ENV=py37-django111-drf310
     - python: 3.7
+      env: TOX_ENV=py37-django111-drf311
+    - python: 3.7
       env: TOX_ENV=py37-django20-drf37
     - python: 3.7
       env: TOX_ENV=py37-django20-drf38
@@ -50,6 +60,8 @@ matrix:
       env: TOX_ENV=py37-django20-drf39
     - python: 3.7
       env: TOX_ENV=py37-django20-drf310
+    - python: 3.7
+      env: TOX_ENV=py37-django20-drf311
     - python: 3.7
       env: TOX_ENV=py37-django21-drf37
     - python: 3.7
@@ -59,6 +71,8 @@ matrix:
     - python: 3.7
       env: TOX_ENV=py37-django21-drf310
     - python: 3.7
+      env: TOX_ENV=py37-django21-drf311
+    - python: 3.7
       env: TOX_ENV=py37-django22-drf37
     - python: 3.7
       env: TOX_ENV=py37-django22-drf38
@@ -66,6 +80,8 @@ matrix:
       env: TOX_ENV=py37-django22-drf39
     - python: 3.7
       env: TOX_ENV=py37-django22-drf310
+    - python: 3.7
+      env: TOX_ENV=py37-django22-drf311
     - python: 3.8-dev
       env: TOX_ENV=py38-django111-drf37
     - python: 3.8-dev
@@ -75,6 +91,8 @@ matrix:
     - python: 3.8-dev
       env: TOX_ENV=py38-django111-drf310
     - python: 3.8-dev
+      env: TOX_ENV=py38-django111-drf311
+    - python: 3.8-dev
       env: TOX_ENV=py38-django20-drf37
     - python: 3.8-dev
       env: TOX_ENV=py38-django20-drf38
@@ -82,6 +100,8 @@ matrix:
       env: TOX_ENV=py38-django20-drf39
     - python: 3.8-dev
       env: TOX_ENV=py38-django20-drf310
+    - python: 3.8-dev
+      env: TOX_ENV=py38-django20-drf311
     - python: 3.8-dev
       env: TOX_ENV=py38-django21-drf37
     - python: 3.8-dev
@@ -91,6 +111,8 @@ matrix:
     - python: 3.8-dev
       env: TOX_ENV=py38-django21-drf310
     - python: 3.8-dev
+      env: TOX_ENV=py38-django21-drf311
+    - python: 3.8-dev
       env: TOX_ENV=py38-django22-drf37
     - python: 3.8-dev
       env: TOX_ENV=py38-django22-drf38
@@ -98,6 +120,8 @@ matrix:
       env: TOX_ENV=py38-django22-drf39
     - python: 3.8-dev
       env: TOX_ENV=py38-django22-drf310
+    - python: 3.8-dev
+      env: TOX_ENV=py38-django22-drf311
     - python: 3.7
       env: TOX_ENV=lint
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
     - python: 3.6
       env: TOX_ENV=py36-django111-drf311
     - python: 3.6
+      env: TOX_ENV=py36-django111-drf312
+    - python: 3.6
       env: TOX_ENV=py36-django20-drf37
     - python: 3.6
       env: TOX_ENV=py36-django20-drf38
@@ -22,6 +24,8 @@ matrix:
       env: TOX_ENV=py36-django20-drf310
     - python: 3.6
       env: TOX_ENV=py36-django20-drf311
+    - python: 3.6
+      env: TOX_ENV=py36-django20-drf312
     - python: 3.6
       env: TOX_ENV=py36-django21-drf37
     - python: 3.6
@@ -33,6 +37,8 @@ matrix:
     - python: 3.6
       env: TOX_ENV=py36-django21-drf311
     - python: 3.6
+      env: TOX_ENV=py36-django21-drf312
+    - python: 3.6
       env: TOX_ENV=py36-django22-drf37
     - python: 3.6
       env: TOX_ENV=py36-django22-drf38
@@ -42,6 +48,8 @@ matrix:
       env: TOX_ENV=py36-django22-drf310
     - python: 3.6
       env: TOX_ENV=py36-django22-drf311
+    - python: 3.6
+      env: TOX_ENV=py36-django22-drf312
     - python: 3.7
       env: TOX_ENV=py37-django111-drf37
     - python: 3.7
@@ -53,6 +61,8 @@ matrix:
     - python: 3.7
       env: TOX_ENV=py37-django111-drf311
     - python: 3.7
+      env: TOX_ENV=py37-django111-drf312
+    - python: 3.7
       env: TOX_ENV=py37-django20-drf37
     - python: 3.7
       env: TOX_ENV=py37-django20-drf38
@@ -62,6 +72,8 @@ matrix:
       env: TOX_ENV=py37-django20-drf310
     - python: 3.7
       env: TOX_ENV=py37-django20-drf311
+    - python: 3.7
+      env: TOX_ENV=py37-django20-drf312
     - python: 3.7
       env: TOX_ENV=py37-django21-drf37
     - python: 3.7
@@ -73,6 +85,8 @@ matrix:
     - python: 3.7
       env: TOX_ENV=py37-django21-drf311
     - python: 3.7
+      env: TOX_ENV=py37-django21-drf312
+    - python: 3.7
       env: TOX_ENV=py37-django22-drf37
     - python: 3.7
       env: TOX_ENV=py37-django22-drf38
@@ -82,6 +96,8 @@ matrix:
       env: TOX_ENV=py37-django22-drf310
     - python: 3.7
       env: TOX_ENV=py37-django22-drf311
+    - python: 3.7
+      env: TOX_ENV=py37-django22-drf312
     - python: 3.8-dev
       env: TOX_ENV=py38-django111-drf37
     - python: 3.8-dev
@@ -93,6 +109,8 @@ matrix:
     - python: 3.8-dev
       env: TOX_ENV=py38-django111-drf311
     - python: 3.8-dev
+      env: TOX_ENV=py38-django111-drf312
+    - python: 3.8-dev
       env: TOX_ENV=py38-django20-drf37
     - python: 3.8-dev
       env: TOX_ENV=py38-django20-drf38
@@ -102,6 +120,8 @@ matrix:
       env: TOX_ENV=py38-django20-drf310
     - python: 3.8-dev
       env: TOX_ENV=py38-django20-drf311
+    - python: 3.8-dev
+      env: TOX_ENV=py38-django20-drf312
     - python: 3.8-dev
       env: TOX_ENV=py38-django21-drf37
     - python: 3.8-dev
@@ -113,6 +133,8 @@ matrix:
     - python: 3.8-dev
       env: TOX_ENV=py38-django21-drf311
     - python: 3.8-dev
+      env: TOX_ENV=py38-django21-drf312
+    - python: 3.8-dev
       env: TOX_ENV=py38-django22-drf37
     - python: 3.8-dev
       env: TOX_ENV=py38-django22-drf38
@@ -122,6 +144,8 @@ matrix:
       env: TOX_ENV=py38-django22-drf310
     - python: 3.8-dev
       env: TOX_ENV=py38-django22-drf311
+    - python: 3.8-dev
+      env: TOX_ENV=py38-django22-drf312
     - python: 3.7
       env: TOX_ENV=lint
     - python: 3.7

--- a/rest_framework_friendly_errors/mixins.py
+++ b/rest_framework_friendly_errors/mixins.py
@@ -178,9 +178,15 @@ class FriendlyErrorMessagesMixin(FieldMap):
             if parent:
                 initial_data = self.initial_data[parent.field_name]
                 for data in initial_data:
-                    validator(data[field.field_name])
+                    if getattr(validator, 'requires_context', False):
+                        validator(data[field.field_name], field)
+                    else:
+                        validator(data[field.field_name])
             else:
-                validator(self.initial_data[field.field_name])
+                if getattr(validator, 'requires_context', False):
+                    validator(self.initial_data[field.field_name], field)
+                else:
+                    validator(self.initial_data[field.field_name])
         except (DjangoValidationError, RestValidationError) as err:
             err_message = err.detail[0] \
                 if hasattr(err, 'detail') else err.message

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ addopts=--tb=short
 
 [tox]
 envlist =
-       py{36,37,38}-django{111,20,21,22}-drf{37,38,39,310},
+       py{36,37,38}-django{111,20,21,22}-drf{37,38,39,310,311},
        lint
 
 [testenv]
@@ -21,6 +21,7 @@ deps =
         drf38: djangorestframework>=3.8,<3.9
         drf39: djangorestframework>=3.9,<3.10
         drf310: djangorestframework>=3.10,<3.11
+        drf311: djangorestframework>=3.11,<3.12
         -rrequirements/requirements-testing.txt
 basepython =
     py36: python3.6

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ addopts=--tb=short
 
 [tox]
 envlist =
-       py{36,37,38}-django{111,20,21,22}-drf{37,38,39,310,311},
+       py{36,37,38}-django{111,20,21,22}-drf{37,38,39,310,311,312},
        lint
 
 [testenv]
@@ -22,6 +22,7 @@ deps =
         drf39: djangorestframework>=3.9,<3.10
         drf310: djangorestframework>=3.10,<3.11
         drf311: djangorestframework>=3.11,<3.12
+        drf312: djangorestframework>=3.12,<3.13
         -rrequirements/requirements-testing.txt
 basepython =
     py36: python3.6


### PR DESCRIPTION
In encode/django-rest-framework#7062 the API for calling DRF validators changed to require the caller to inspect the validator instance to determine if the validator requires a second argument at call time.